### PR TITLE
feat: include user name and build SHA in feedback payload

### DIFF
--- a/app.js
+++ b/app.js
@@ -2867,6 +2867,8 @@ async function submitFeedback() {
         rating,
         version: APP_VERSION,
         lang: state.lang,
+        name: state.profile.name || "",
+        buildSha: BUILD_SHA,
       }),
     });
     if (!res.ok) throw new Error("HTTP " + res.status);

--- a/tests/feedback.spec.js
+++ b/tests/feedback.spec.js
@@ -84,6 +84,8 @@ test.describe("feedback form", () => {
     expect(captured.message).toContain("dark mode");
     expect(captured.version).toBeTruthy();
     expect(captured.lang).toBe("en");
+    expect(captured.name).toBe("Test");
+    expect(captured.buildSha).toBeTruthy();
   });
 
   test("shows error toast when worker returns error", async ({ page }) => {

--- a/worker/feedback.js
+++ b/worker/feedback.js
@@ -134,6 +134,10 @@ async function handleFeedback(request, env, cors) {
     return jsonResponse({ error: "Invalid JSON" }, 400, cors);
   }
 
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return jsonResponse({ error: "Invalid request body" }, 400, cors);
+  }
+
   const { type, message, rating, version, lang, name, buildSha } = body;
 
   if (!message || typeof message !== "string") {
@@ -170,9 +174,9 @@ async function handleFeedback(request, env, cors) {
       ? `**Rating:** ${"★".repeat(rating)}${"☆".repeat(5 - rating)} (${rating}/5)`
       : "**Rating:** not rated",
     `**App version:** ${version || "unknown"}`,
-    `**Build:** ${buildSha && !buildSha.startsWith("__") ? buildSha : "dev"}`,
+    `**Build:** ${typeof buildSha === "string" && buildSha.trim() && !buildSha.startsWith("__") ? buildSha : "dev"}`,
     `**Language:** ${lang || "unknown"}`,
-    `**User:** ${name || "anonymous"}`,
+    `**User:** ${typeof name === "string" && name.trim() ? name.trim().slice(0, 100) : "anonymous"}`,
     "_Submitted via in-app feedback_",
   ].join("\n");
 

--- a/worker/feedback.js
+++ b/worker/feedback.js
@@ -134,7 +134,7 @@ async function handleFeedback(request, env, cors) {
     return jsonResponse({ error: "Invalid JSON" }, 400, cors);
   }
 
-  const { type, message, rating, version, lang } = body;
+  const { type, message, rating, version, lang, name, buildSha } = body;
 
   if (!message || typeof message !== "string") {
     return jsonResponse({ error: "Message is required" }, 400, cors);
@@ -170,7 +170,9 @@ async function handleFeedback(request, env, cors) {
       ? `**Rating:** ${"★".repeat(rating)}${"☆".repeat(5 - rating)} (${rating}/5)`
       : "**Rating:** not rated",
     `**App version:** ${version || "unknown"}`,
+    `**Build:** ${buildSha && !buildSha.startsWith("__") ? buildSha : "dev"}`,
     `**Language:** ${lang || "unknown"}`,
+    `**User:** ${name || "anonymous"}`,
     "_Submitted via in-app feedback_",
   ].join("\n");
 


### PR DESCRIPTION
Extends the feedback submission to include the user's profile name and the build SHA in the payload sent to the Cloudflare Worker. The worker now renders these as **User** and **Build** fields in the created GitHub issue.

### Changes
- **app.js**: Added \
ame\ and \uildSha\ to the feedback POST body
- **worker/feedback.js**: Destructures new fields and adds Build/User lines to the issue body
- **tests/feedback.spec.js**: Asserts \
ame\ and \uildSha\ are present in captured payload