### PR TITLE
fix: improve PWA manifest for richer install UI and icon correctness

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,7 @@
   "name": "habit.io",
   "short_name": "habit.io",
   "description": "Improve your life with science-backed habits — personalised, private, and offline-first. No account needed.",
+  "id": "/",
   "start_url": "/",
   "scope": "/",
   "display": "standalone",
@@ -13,19 +14,46 @@
       "src": "icons/icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "icons/icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "icons/icon.svg",
       "sizes": "any",
       "type": "image/svg+xml",
       "purpose": "any"
+    }
+  ],
+  "screenshots": [
+    {
+      "src": "docs/screenshot-tracker.png",
+      "sizes": "786x1704",
+      "type": "image/png",
+      "label": "habit.io — daily tracker"
+    },
+    {
+      "src": "docs/desktop-preview.png",
+      "sizes": "1280x800",
+      "type": "image/png",
+      "form_factor": "wide",
+      "label": "habit.io — desktop overview"
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -46,6 +46,7 @@
       "src": "docs/screenshot-tracker.png",
       "sizes": "786x1704",
       "type": "image/png",
+      "form_factor": "narrow",
       "label": "habit.io — daily tracker"
     },
     {


### PR DESCRIPTION
## Summary
- Add `id: "/"` to pin app identity to canonical deployment root
- Split combined `"any maskable"` icon purpose into separate `"any"` and `"maskable"` entries (combined value is discouraged — causes padding issues on some platforms)
- Add `screenshots` array: mobile (786×1704, no form_factor) and desktop (1280×800, form_factor: wide) for richer PWA install UI on both mobile and desktop

## Test plan
- [ ] Install PWA on mobile — verify richer install sheet shows mobile screenshot
- [ ] Install PWA on desktop Chrome — verify richer install dialog shows desktop screenshot
- [ ] Verify no DevTools manifest warnings remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)