### PR TITLE
feat(settings): add update checker with force-refresh (v2.13)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
-const STORAGE_VERSION = "habitio_v12";
-const APP_VERSION = "v2.12";
+const STORAGE_VERSION = "habitio_v13";
+const APP_VERSION = "v2.13";
 const BUILD_SHA = "__BUILD_SHA__";
+let _updateStatus = null; // null | 'checking' | 'up-to-date' | 'available' | 'error'
 // Replace with your deployed worker URL after running: wrangler deploy
 const WORKER_BASE_URL = "https://habitio-feedback.rafal-sladek.workers.dev";
 const FEEDBACK_WORKER_URL = WORKER_BASE_URL;
@@ -665,6 +666,7 @@ function applyDataMigration(d) {
 }
 
 function cleanupOldStorageKeys() {
+  localStorage.removeItem("habitio_v12");
   localStorage.removeItem("habitio_v11");
   localStorage.removeItem("habitio_v10");
   localStorage.removeItem("habitio_v9");
@@ -682,6 +684,7 @@ function load() {
     // Migration: read from older keys if current key is absent
     const raw =
       localStorage.getItem(STORAGE_VERSION) ||
+      localStorage.getItem("habitio_v12") ||
       localStorage.getItem("habitio_v11") ||
       localStorage.getItem("habitio_v10") ||
       localStorage.getItem("habitio_v9") ||
@@ -2953,7 +2956,27 @@ function renderSettings() {
     t("about_on_device") +
     '</span></div><div class="setting-item" style="cursor:default"><div class="setting-left"><span class="setting-emoji">🔨</span><span class="setting-label">Build</span></div><span class="setting-action" style="font-family:monospace;font-size:12px">' +
     (BUILD_SHA.startsWith("__") ? "dev" : BUILD_SHA) +
-    '</span></div><div class="setting-item" onclick="shareApp()"><div class="setting-left"><span class="setting-emoji">🔗</span><span class="setting-label">' +
+    "</span></div>" +
+    (BUILD_SHA.startsWith("__")
+      ? ""
+      : '<div id="update-row" class="setting-item" style="cursor:' +
+        (_updateStatus === "available" ? "pointer" : "default") +
+        '"' +
+        (_updateStatus === "available" ? ' onclick="forceUpdate()"' : "") +
+        '><div class="setting-left"><span class="setting-emoji">🔄</span><span class="setting-label" id="update-label">' +
+        (_updateStatus === "available"
+          ? t("update_available")
+          : _updateStatus === "up-to-date"
+            ? t("update_up_to_date")
+            : t("update_checking")) +
+        '</span></div><span class="setting-action" id="update-action">' +
+        (_updateStatus === "available"
+          ? t("update_now")
+          : _updateStatus === "up-to-date"
+            ? "✓"
+            : "") +
+        "</span></div>") +
+    '<div class="setting-item" onclick="shareApp()"><div class="setting-left"><span class="setting-emoji">🔗</span><span class="setting-label">' +
     t("share_app") +
     '</span></div><span class="setting-action">›</span></div><div class="setting-item" onclick="setConsent(' +
     !state.consentAnalytics +
@@ -3017,6 +3040,48 @@ function renderSettings() {
     '<button id="feedback-submit" onclick="submitFeedback()" style="background:var(--accent);color:#fff;border:none;border-radius:10px;padding:10px 20px;font-size:14px;font-weight:600;cursor:pointer">' +
     t("feedback_submit") +
     "</button></div></div></div>";
+  if (!BUILD_SHA.startsWith("__") && _updateStatus === null) {
+    _updateStatus = "checking";
+    setTimeout(checkForUpdate, 0);
+  }
+}
+async function checkForUpdate() {
+  try {
+    const res = await fetch("./app.js?_v=" + Date.now(), { cache: "no-store" });
+    if (!res.ok) throw new Error("fetch failed");
+    const text = await res.text();
+    const match = text.match(/BUILD_SHA\s*=\s*"([^"]+)"/);
+    const serverSha = match ? match[1] : null;
+    _updateStatus = serverSha && serverSha !== BUILD_SHA ? "available" : "up-to-date";
+  } catch {
+    _updateStatus = "error";
+  }
+  const rowEl = document.getElementById("update-row");
+  const labelEl = document.getElementById("update-label");
+  const actionEl = document.getElementById("update-action");
+  if (!rowEl) return;
+  if (_updateStatus === "available") {
+    if (labelEl) labelEl.textContent = t("update_available");
+    if (actionEl) actionEl.textContent = t("update_now");
+    rowEl.style.cursor = "pointer";
+    rowEl.setAttribute("onclick", "forceUpdate()");
+  } else if (_updateStatus === "up-to-date") {
+    if (labelEl) labelEl.textContent = t("update_up_to_date");
+    if (actionEl) actionEl.textContent = "✓";
+  } else {
+    rowEl.style.display = "none";
+  }
+}
+async function forceUpdate() {
+  if ("caches" in window) {
+    const keys = await caches.keys();
+    await Promise.all(keys.map((k) => caches.delete(k)));
+  }
+  if ("serviceWorker" in navigator) {
+    const regs = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(regs.map((r) => r.unregister()));
+  }
+  location.reload();
 }
 function setFeedbackStar(n) {
   document.querySelectorAll("#feedback-stars button").forEach((btn) => {

--- a/i18n.js
+++ b/i18n.js
@@ -341,6 +341,10 @@ const T = {
         a: "James Clear",
       },
     ],
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
   },
   de: {
     nav_today: "Heute",
@@ -627,6 +631,10 @@ const T = {
     coach_unlock_toast:
       "Mach erst 3 getrackte Tage voll, dann wird deine Coach-Reflexion freigeschaltet.",
     coach_budget_status: "{used} / {limit} KI-Coach-Anfragen heute genutzt",
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
     quotes: [
       {
         q: "Jede Handlung, die du tust, ist eine Stimme für die Person, die du sein möchtest.",
@@ -946,6 +954,10 @@ const T = {
     coach_unlock_note: "Po 3 dniach śledzenia pojawi się tutaj refleksja coacha.",
     coach_unlock_toast: "Działaj jeszcze przez 3 dni, aby odblokować refleksję coacha.",
     coach_budget_status: "Dziś wykorzystano {used} z {limit} próśb do trenera AI",
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
     quotes: [
       { q: "Każde twoje działanie to głos za osobą, którą chcesz się stać.", a: "James Clear" },
       {
@@ -1260,6 +1272,10 @@ const T = {
     coach_unlock_note: "Depois de 3 dias registrados, sua reflexão vai aparecer aqui.",
     coach_unlock_toast: "Siga por mais 3 dias para desbloquear sua reflexão do coach.",
     coach_budget_status: "{used} / {limit} pedidos ao coach de IA usados hoje",
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
     quotes: [
       {
         q: "Cada ação que você realiza é um voto pelo tipo de pessoa que deseja se tornar.",
@@ -1577,6 +1593,10 @@ const T = {
     coach_unlock_note: "После 3 дней отслеживания здесь появится ваша рефлексия.",
     coach_unlock_toast: "Продолжайте ещё 3 дня, чтобы открыть свою рефлексию.",
     coach_budget_status: "Сегодня использовано {used} из {limit} запросов к ИИ-коучу",
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
     quotes: [
       {
         q: "Каждое действие, которое ты совершаешь, — это голос за того человека, которым ты хочешь стать.",
@@ -1898,6 +1918,10 @@ const T = {
     coach_unlock_note: "Après 3 jours suivis, votre réflexion apparaîtra ici.",
     coach_unlock_toast: "Continuez pendant 3 jours pour débloquer votre réflexion.",
     coach_budget_status: "{used} / {limit} demandes au coach IA utilisées aujourd'hui",
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
     quotes: [
       {
         q: "Chaque action que tu entreprends est un vote pour le type de personne que tu souhaites devenir.",
@@ -2217,6 +2241,10 @@ const T = {
     coach_unlock_note: "3 ट्रैक किए गए दिनों के बाद आपकी कोच समीक्षा यहाँ दिखेगी।",
     coach_unlock_toast: "3 ट्रैक किए गए दिन पूरे करें, फिर आपकी कोच समीक्षा खुल जाएगी।",
     coach_budget_status: "आज {used} / {limit} AI coach अनुरोध उपयोग किए गए",
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
     quotes: [
       {
         q: "आप जो हर कदम उठाते हैं, वह उस व्यक्ति के लिए एक वोट है जो आप बनना चाहते हैं।",
@@ -2533,6 +2561,10 @@ const T = {
     coach_unlock_note: "Після 3 днів відстеження тут з’явиться ваша рефлексія.",
     coach_unlock_toast: "Продовжуйте ще 3 дні, щоб відкрити свою рефлексію.",
     coach_budget_status: "Сьогодні використано {used} з {limit} запитів до AI-коуча",
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
     quotes: [
       {
         q: "Кожна дія, яку ти здійснюєш, — це голос за людину, якою ти хочеш стати.",
@@ -2833,6 +2865,10 @@ const T = {
     coach_unlock_note: "بعد 3 أيام من التتبع ستظهر مراجعة المدرب هنا.",
     coach_unlock_toast: "استمر 3 أيام في التتبع لفتح مراجعة المدرب.",
     coach_budget_status: "تم استخدام {used} من {limit} من طلبات مدرب الذكاء الاصطناعي اليوم",
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
     quotes: [
       { q: "كل فعل تقوم به هو تصويت للشخص الذي تريد أن تصبح.", a: "James Clear" },
       { q: "أنت لا ترتقي إلى مستوى أهدافك. أنت تنحدر إلى مستوى أنظمتك.", a: "James Clear" },
@@ -3143,6 +3179,10 @@ const T = {
     coach_unlock_note: "Pas 3 ditësh të regjistruara, reflektimi yt do të shfaqet këtu.",
     coach_unlock_toast: "Vazhdo edhe 3 ditë për të zhbllokuar reflektimin tënd.",
     coach_budget_status: "Sot janë përdorur {used} nga {limit} kërkesa për trajnerin AI",
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
     quotes: [
       {
         q: "Çdo veprim që ndërmerrni është një votë për llojin e personit që dëshironi të bëheni.",
@@ -3451,6 +3491,10 @@ const T = {
     coach_unlock_note: "После 3 дана праћења, твоја рефлексија ће се појавити овде.",
     coach_unlock_toast: "Настави још 3 дана да откључаш своју рефлексију.",
     coach_budget_status: "Данас је искоришћено {used} од {limit} захтева ка AI тренеру",
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
     quotes: [
       {
         q: "Свака радња коју предузимаш је глас за особу коју желиш да постанеш.",
@@ -3762,6 +3806,10 @@ const T = {
     coach_unlock_note: "Noch 3 getrackten Dog erscheint do deine Coach-Reflexion.",
     coach_unlock_toast: "Mach no 3 getrackte Dog, dann werd deine Coach-Reflexion freigschoid.",
     coach_budget_status: "{used} / {limit} KI-Coach-Anfragen heit gnutzt",
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
     quotes: [
       {
         q: "Jeda Schritt, wos'd machst, is a Stimm für de Person, de du wern wuist.",
@@ -4079,6 +4127,10 @@ const T = {
     coach_unlock_note: "Después de 3 días registrados, aquí aparecerá tu reflexión del coach.",
     coach_unlock_toast: "Sigue 3 días registrados para desbloquear tu reflexión del coach.",
     coach_budget_status: "Hoy se usaron {used} de {limit} solicitudes al coach de IA",
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
     quotes: [
       {
         q: "Cada acción que realizas es un voto por el tipo de persona en que deseas convertirte.",
@@ -4393,6 +4445,10 @@ const T = {
     coach_unlock_note: "Dopo 3 giorni tracciati, qui apparirà la tua riflessione del coach.",
     coach_unlock_toast: "Continua per 3 giorni tracciati per sbloccare la riflessione del coach.",
     coach_budget_status: "Oggi hai usato {used} di {limit} richieste al coach AI",
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
     quotes: [
       {
         q: "Ogni azione che compi è un voto per il tipo di persona che vuoi diventare.",
@@ -4499,6 +4555,10 @@ const T = {
     coach_reflection_placeholder: "Gânduri de azi…",
     coach_save: "Salvează",
     coach_budget_status: "Astăzi ai folosit {used} din {limit} cereri către coachul AI",
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
     coach_privacy_note:
       "Doar când ceri, habit.io partajează un scurt rezumat al progresului tău recent. Poți include și cele mai noi note din jurnal.",
     coach_focus_placeholder:
@@ -4863,6 +4923,10 @@ const T = {
     coach_reflection_placeholder: "Gedachten van vandaag…",
     coach_save: "Opslaan",
     coach_budget_status: "Vandaag zijn {used} van {limit} AI-coachverzoeken gebruikt",
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
     coach_privacy_note:
       "Alleen wanneer je daarom vraagt, deelt habit.io een korte samenvatting van je recente voortgang. Je kunt ook je nieuwste dagboeknotities opnemen.",
     coach_focus_placeholder:
@@ -5227,6 +5291,10 @@ const T = {
     coach_reflection_placeholder: "Bugünün düşünceleri…",
     coach_save: "Kaydet",
     coach_budget_status: "Bugün {used} / {limit} yapay zeka koçu isteği kullanıldı",
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
     coach_privacy_note:
       "Sadece sen istediğinde, habit.io son ilerlemenin kısa bir özetini paylaşır. Dilersen en son günlük notlarını da ekleyebilirsin.",
     coach_focus_placeholder:
@@ -5585,6 +5653,10 @@ const T = {
     coach_reflection_placeholder: "Σκέψεις σήμερα…",
     coach_save: "Αποθήκευση",
     coach_budget_status: "Σήμερα χρησιμοποιήθηκαν {used} από {limit} αιτήματα προς τον AI coach",
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
     coach_privacy_note:
       "Μόνο όταν το ζητήσεις, το habit.io μοιράζεται μια σύντομη εικόνα της πρόσφατης προόδου σου. Μπορείς επίσης να συμπεριλάβεις τις τελευταίες σημειώσεις ημερολογίου.",
     coach_focus_placeholder:
@@ -5954,6 +6026,10 @@ const T = {
     coach_reflection_placeholder: "Misli od danas…",
     coach_save: "Spremi",
     coach_budget_status: "Danas je iskorišteno {used} od {limit} zahtjeva za AI coach",
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
     coach_privacy_note:
       "Samo kada to zatražiš, habit.io dijeli kratki pregled tvog nedavnog napretka. Možeš uključiti i svoje najnovije bilješke iz dnevnika.",
     coach_focus_placeholder:
@@ -6318,6 +6394,10 @@ const T = {
     coach_reflection_placeholder: "Pensaments d'avui…",
     coach_save: "Desa",
     coach_budget_status: "Avui s'han utilitzat {used} de {limit} sol·licituds al coach d'IA",
+    update_checking: "Checking for updates…",
+    update_available: "Update available",
+    update_up_to_date: "Up to date",
+    update_now: "Update",
     coach_privacy_note:
       "Només quan ho demanes, habit.io comparteix un breu resum del teu progrés recent. També pots incloure les teves últimes notes del diari.",
     coach_focus_placeholder:

--- a/scripts/take-screenshots.js
+++ b/scripts/take-screenshots.js
@@ -7,7 +7,7 @@ const path = require("path");
 
 const BASE_URL = "http://localhost:3000";
 const DOCS_DIR = path.join(__dirname, "..", "docs");
-const STORAGE_VERSION = "habitio_v12";
+const STORAGE_VERSION = "habitio_v13";
 
 // The app uses toISOString().slice(0,10) for date keys (UTC-based).
 // We must use the same UTC date so diary/checks align with "today" in the app.
@@ -214,12 +214,12 @@ async function main() {
     await mobile.waitForTimeout(400);
     await mobile.screenshot({ path: path.join(DOCS_DIR, "screenshot-tracker.png"), fullPage: true });
 
-    // 3. Add-habit modal open — 1 habit seeded so FAB is visible, modal scrolled to CTA
+    // 3. Add-habit modal open — invoke openAddModal() directly, scroll CTA into view
     console.log("  screenshot-add-habit.png");
     const stateOneHabit = { ...SEED_STATE, habits: [SEED_STATE.habits[0]] };
     await loadWithState(mobile, stateOneHabit);
-    await mobile.click("#fab-add");
-    await mobile.waitForSelector("#add-modal.show", { timeout: 3000 }).catch(() => {});
+    await mobile.evaluate(() => window.openAddModal());
+    await mobile.waitForSelector("#add-modal.show", { timeout: 5000 }).catch(() => {});
     await mobile.waitForTimeout(400);
     // Scroll the modal to the bottom so the Save CTA button is visible
     await mobile.evaluate(() => {
@@ -229,7 +229,7 @@ async function main() {
     await mobile.waitForTimeout(300);
     await mobile.screenshot({ path: path.join(DOCS_DIR, "screenshot-add-habit.png") });
 
-    // 4. Journal — show first step (grateful)
+    // 4. Journal — show first step (grateful, empty diary)
     console.log("  screenshot-journal.png");
     const stateNoDiary = { ...SEED_STATE, diary: {} };
     await loadWithState(mobile, stateNoDiary);
@@ -237,19 +237,21 @@ async function main() {
     await mobile.waitForTimeout(600);
     await mobile.screenshot({ path: path.join(DOCS_DIR, "screenshot-journal.png") });
 
-    // 5. Stats page — scroll to show all graphs
+    // 5. Journal summary — all fields filled → switchPage auto-calls calcDiaryStep() → shows ✨ summary
+    console.log("  screenshot-journal-summary.png");
+    await loadWithState(mobile, SEED_STATE); // SEED_STATE has today's diary complete
+    await mobile.locator(".nav-tab").nth(1).click();
+    await mobile.waitForTimeout(600);
+    await mobile.screenshot({ path: path.join(DOCS_DIR, "screenshot-journal-summary.png") });
+
+    // 6. Stats page — full page (includes mood trend + AI coach panel at bottom)
     console.log("  screenshot-stats.png");
     await loadWithState(mobile, SEED_STATE);
     await mobile.locator(".nav-tab").nth(2).click();
     await mobile.waitForTimeout(800);
-    // Scroll down to show mood trends and other charts
-    await mobile.evaluate(() => {
-      window.scrollTo(0, document.body.scrollHeight);
-    });
-    await mobile.waitForTimeout(400);
     await mobile.screenshot({ path: path.join(DOCS_DIR, "screenshot-stats.png"), fullPage: true });
 
-    // 6. Settings page — full page capture
+    // 7. Settings page — full page capture
     console.log("  screenshot-settings.png");
     await loadWithState(mobile, SEED_STATE);
     await mobile.locator(".nav-tab").nth(3).click();
@@ -303,7 +305,7 @@ async function main() {
     // 12. Desktop modal (add habit open)
     console.log("  desktop-modal.png");
     await loadWithState(desktop, SEED_STATE);
-    await desktop.click("#fab-add");
+    await desktop.evaluate(() => window.openAddModal());
     await desktop.waitForTimeout(600);
     await desktop.screenshot({ path: path.join(DOCS_DIR, "desktop-modal.png") });
 
@@ -327,7 +329,7 @@ async function main() {
 
     await tabletCtx.close();
 
-    console.log("\n✅ All 13 screenshots saved to docs/");
+    console.log("\n✅ All 14 screenshots saved to docs/");
   } finally {
     await browser.close();
   }

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = "habitio_v12";
+const CACHE = "habitio_v13";
 
 const PRECACHE = [
   "./",

--- a/tests/flows.spec.js
+++ b/tests/flows.spec.js
@@ -92,7 +92,7 @@ test.describe("after onboarding", () => {
     await expect(page.getByText("Export Backup")).toBeVisible();
     await expect(page.getByText("Import Backup")).toBeVisible();
     await expect(page.getByText("Reset All Data")).toBeVisible();
-    await expect(page.getByText("habit.io v2.12")).toBeVisible();
+    await expect(page.getByText("habit.io v2.13")).toBeVisible();
   });
 
   test("settings shows saved profile", async ({ page }) => {

--- a/tests/load-migration.spec.js
+++ b/tests/load-migration.spec.js
@@ -2,7 +2,7 @@
 const { test, expect } = require("./test-helpers");
 
 const OLD_KEY = "habitio_v9";
-const NEW_KEY = "habitio_v12";
+const NEW_KEY = "habitio_v13";
 
 /** Ensure `load()` migrates old state keys into the current storage key */
 test("migrates old storage key into new key on load", async ({ page }) => {

--- a/tests/sw.spec.js
+++ b/tests/sw.spec.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const vm = require("node:vm");
 
 /** Must match CACHE in sw.js and STORAGE_VERSION in app.js */
-const STORAGE_VERSION = "habitio_v12";
+const STORAGE_VERSION = "habitio_v13";
 
 function cloneResponse(response) {
   return response ? response.clone() : undefined;

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const gaRouteInstalled = new WeakSet();
 
 /** Must match STORAGE_VERSION in app.js and CACHE in sw.js */
-const STORAGE_VERSION = "habitio_v12";
+const STORAGE_VERSION = "habitio_v13";
 
 const test = base.extend({
   coverageRecorder: [


### PR DESCRIPTION
## Summary

- Adds 🔄 update-checker row in Settings (below Build SHA) that detects stale PWA installs
- Compares running `BUILD_SHA` against server's `app.js` — shows **Update available** button when mismatched
- `forceUpdate()` clears all SW caches, unregisters SW, and reloads — guarantees fresh files
- Hidden in dev mode (`BUILD_SHA = "__BUILD_SHA__"`); persists state across settings re-renders without re-fetching
- Bumps v2.12 → v2.13; v12 → v13 storage migration with data preservation

## Test plan

- [ ] Open Settings on deployed build — row shows "Checking for updates…" then "Up to date ✓"
- [ ] Simulate stale build: manually change `BUILD_SHA` in console → row shows "Update available" + tap updates the app
- [ ] Dev mode (`__BUILD_SHA__`): update row is hidden
- [ ] Navigate away from Settings and back — correct state shown immediately (no re-fetch)
- [ ] `yarn test` passes (4 browser projects)
- [ ] `node scripts/validate-i18n.js` → `✓ All languages have all keys!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)